### PR TITLE
Fix PATH environment variable setup to preserve existing entries

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -50,10 +50,18 @@ function Set-PathExt {
         return
     }
     
-    # Define variável opcional
+    # Adiciona o diretório do Publicador ao PATH existente, sem sobrescrevê-lo
+    $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $newPath = if ([string]::IsNullOrEmpty($currentPath)) {
+        $publisherRoot
+    }
+    else {
+        "$currentPath;$publisherRoot"
+    }
+
     [Environment]::SetEnvironmentVariable(
         "Path",
-        $publisherRoot,
+        $newPath,
         "User"
     )
 


### PR DESCRIPTION
## Summary
Fixed the `Set-PathExt` function in setup.ps1 to append the publisher directory to the existing PATH instead of overwriting it entirely.

## Key Changes
- Modified PATH environment variable assignment to preserve existing user PATH entries
- Added logic to check if PATH is empty before concatenation
- Constructs new PATH by appending `$publisherRoot` to the current PATH with semicolon separator
- Updated comment to better reflect the actual behavior (Portuguese: "Adiciona o diretório do Publicador ao PATH existente, sem sobrescrevê-lo")

## Implementation Details
The fix retrieves the current user PATH using `[Environment]::GetEnvironmentVariable("Path", "User")` and conditionally builds the new PATH value:
- If current PATH is empty/null, uses only `$publisherRoot`
- Otherwise, concatenates existing PATH with the new directory: `"$currentPath;$publisherRoot"`

This prevents loss of other important directories in the user's PATH during setup.

https://claude.ai/code/session_0135gg1b6CrwYGCS1fpz6KAT