### PR TITLE
Fix syntax error in Set-PathExtPS1 function

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -3,7 +3,7 @@ Import-Module ".\modules\WriteFunctions.psm1"
 function Set-PathExtPS1 {
     if (Confirm-PathExtPS1) {
         Write-Info ".PS1 já está no PATHEXT."
-        retur;
+        return
     }
 
     Write-Log "Adicionando extensão .ps1"    


### PR DESCRIPTION
## Summary
Fixed a typo in the `Set-PathExtPS1` function that was preventing the script from executing correctly.

## Changes
- Corrected `retur;` to `return` in the early exit condition of the `Set-PathExtPS1` function

## Details
The function had a syntax error where the return statement was misspelled as `retur;` with an incorrect semicolon. This has been corrected to the proper PowerShell `return` keyword, allowing the function to properly exit when the .PS1 extension is already present in PATHEXT.

https://claude.ai/code/session_011QtmEVvkMYpe8wqhpfbjPK